### PR TITLE
[Add] ItemFactory 클래스

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -22,6 +22,8 @@ from backend.api.admin import Admin
 from backend.api.auth import Auth
 from backend.api.order import Order
 from backend.api.staff import Staff
+from backend.api.start import Start
+from backend.lib.ItemFactory import ItemFactory
 from backend.setup import initialize_item
 from backend.setup import debug_console
 
@@ -38,13 +40,15 @@ api = Api(
 ) #api정보입력
 
 # ./api/ 폴더 내부 파일들에 작성된 네임스페이스들을 가져온다.
+api.add_namespace(Start, '/start')
 api.add_namespace(Admin, '/admin')
 api.add_namespace(Auth, '/auth')
 api.add_namespace(Order, '/order')
 api.add_namespace(Staff, '/staff')
 
 # 내부 로직이 가동되기 전에 초기화한다
-initialize_item()
+cls_It = ItemFactory()
+cls_It.lazy_init()
 
 # 콘솔에서 디버깅할 수 있도록 하는 도구
 Thread(target=debug_console, daemon=False).start()

--- a/backend/lib/ItemFactory.py
+++ b/backend/lib/ItemFactory.py
@@ -1,0 +1,47 @@
+# 상품들의 인스턴스를 관리하기 위한 클래스.
+# 싱글턴으로 전역에서 접근할 수 있도록 한다.
+
+# 2021.12.02 created by 안태영
+
+
+from backend.lib.GetPutFmDB import GetPutFmDB
+from backend.lib.LoggerSE2 import Logger
+from backend.lib.Items import Items
+
+class ItemFactory(object):
+    def __new__(cls):
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+            cls.logger = Logger()
+        return cls._instance
+
+    def __init__(self) :
+        cls = type(self)
+        if not hasattr(cls, "_init"):
+            cls._init = True
+
+            self.dct_Items: dict[Items] = {}
+
+            self.logger.INFO("ItemFactory init")
+
+    #db초기화 후 실행하기 위해 lazy init을 해줌
+    def lazy_init(self) -> dict[Items]:
+        cls_DB: GetPutFmDB = GetPutFmDB()
+        lst_Items: list = cls_DB.get_items() #DB의 Items테이블에서 정보를 받아온다
+
+        for itemInfo in lst_Items:
+            self.dct_Items[itemInfo[0]] = Items(itemInfo)
+
+        return self.dct_Items # { "itemcode123":Items인스턴스 }
+
+    # 개별 Items인스턴스 리턴
+    def get_instance(self, sItemCode: str) -> Items:
+        if sItemCode in self.dct_Items:
+            return self.dct_Items[sItemCode]
+
+        return Items(('0000', '', '', 0, 0, 0, ''), bTraceCategory=False)
+
+
+    @property #전체 items인스턴스들 리턴(수정 불가)
+    def asset(self) -> dict[Items]: 
+        return self.dct_Items

--- a/backend/lib/Items.py
+++ b/backend/lib/Items.py
@@ -19,7 +19,7 @@ class Items(object):
     __mset_MstCode: set[str] = set() # 초기화 기록용
     __mset_MstCategory: set[str] = set() # 상품코드 추적
 
-    def __new__(cls, tplItemInfo: tuple, sItemCode: str=None):
+    def __new__(cls, tplItemInfo: tuple, sItemCode: str=None, *args):
         #튜플로 생성, str으로 조회
         if sItemCode and sItemCode in cls.__mdct_MstInstance: # 아이템 코드로 호출
             cls._instance = cls.__mdct_MstInstance[sItemCode]
@@ -39,7 +39,7 @@ class Items(object):
         cls.logger.INFO(cls._instance)
         return cls._instance
 
-    def __init__(self, tpleItemInfo: tuple[str,str,str,int,int,int,str], *args) -> None:
+    def __init__(self, tpleItemInfo: tuple[str,str,str,int,int,int,str], *args, bTraceCategory: bool=True) -> None:
         cls = type(self)
         if tpleItemInfo[0] not in cls.__mset_MstCode:
 
@@ -54,7 +54,8 @@ class Items(object):
             self.logger.INFO(f"Item {self._s_Code} init")
 
             cls.__mset_MstCode.add(self._s_Code)
-            cls.__mset_MstCategory.add(self._s_Category) # 카테고리 추적
+            if bTraceCategory: # 더미 데이터 거르기 위함
+                cls.__mset_MstCategory.add(self._s_Category) # 카테고리 추적
 
     def __del__(self):
         print(f"{self.code} collected")

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -1,4 +1,5 @@
 from backend.lib.GetPutFmDB import GetPutFmDB
+from backend.lib.ItemFactory import ItemFactory
 from backend.lib.Items import Items, Items4Order
 from backend.lib.OrderManager import OrderManager
 from backend.lib.UtilsSE2 import LinkedQueue
@@ -6,6 +7,7 @@ from backend.lib.LoggerSE2 import Logger
 
 
 # db에서 상품 정보를 읽어 Items클래스로 찍어내 인스턴스를 생성한다.
+# 2021.12.02 -> itemFactory 클래스로 이전, 사용안함
 def initialize_item() -> dict:
     cls_DB: GetPutFmDB = GetPutFmDB()
     lst_Items: list = cls_DB.get_items() #DB의 Items테이블에서 정보를 받아온다
@@ -22,6 +24,7 @@ def debug_console() -> None:
     logger = Logger()
     cls_Lq = LinkedQueue()
     cls_Om = OrderManager()
+    cls_If = ItemFactory()
 
     while True:
         sInput = input()
@@ -29,7 +32,7 @@ def debug_console() -> None:
             pass
 
         elif sInput in ['i', 'push']:
-            dct_Items = initialize_item() # 상품들 가져온다
+            dct_Items = cls_If.asset # 상품들 가져온다
             logger.DEBUG("possible options: ", dct_Items.keys())
             lst_ItemID = list(map(str, input("specify your options: ").split()))
             if any(id in lst_ItemID for id in dct_Items):


### PR DESCRIPTION
Item인스턴스를 끌어다 사용하기 쉽게 한 곳에서 생성하고 관리한다.
lazy_init()으로 초기화하고 get_instance(sItemCode)로 개별 Items 객체를 불러와 사용한다.
이 경우 sItemCode가 올바르지 않다면 None을 리턴하는 것이 아닌 빈 Items객체를 리턴한다.
상품 목록이 전부 필요하다면 cls_It.asset 과 같은 식으로 호출하면 dict형으로 리턴한다.