### PR TITLE
3차 임시 완성

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Route } from "react-router-dom";
 import Manager from "../src/pages/Manager";
 import Main from "../src/pages/Main";
@@ -11,16 +11,30 @@ import AuthRoute from "./components/Auth/AuthRoute";
 import StaffLogin from "./pages/StaffLogin";
 
 export default function App() {
+  const [isLogin, setIsLogin] = useState(false);
+
   return (
     <div>
-      <Route path="/main" component={Main} />
-      <Route path="/manager" component={Manager} />
+      <Route exact path="/main" component={Main} />
+      <AuthRoute
+        version={1}
+        isLogin={isLogin}
+        exact
+        path="/manager"
+        component={Manager}
+      />
       <Route exact path="/start" component={Start} />
-      <Route exact path="/login" component={Login} />
+      <Route path="/login" render={(props) => <Login {...props} />} />
       <Route path="/complete" component={Complete} />
       <Route path="/order" component={Order} />
       <Route exact path="/StaffLogin" component={StaffLogin} />
-      <Route path="/Staff" component={Staff} />
+      <AuthRoute
+        version={2}
+        isLogin={isLogin}
+        exact
+        path="/Staff"
+        component={Staff}
+      />
     </div>
   );
 }

--- a/frontend/src/components/Auth/AuthRoute.js
+++ b/frontend/src/components/Auth/AuthRoute.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { Route, Redirect } from "react-router-dom";
+import isLogin1 from "../utils/isLogin1";
+import isLogin2 from "../utils/isLogin2";
+
+export default function AuthRoute({ version, component: Component, ...rest }) {
+  if (version === 1) {
+    return (
+      <Route
+        {...rest}
+        render={(props) =>
+          isLogin1() ? <Component {...props} /> : <Redirect to="/login" />
+        }
+      />
+    );
+  } else if (version === 2) {
+    return (
+      <Route
+        {...rest}
+        render={(props) =>
+          isLogin2() ? <Component {...props} /> : <Redirect to="/stafflogin" />
+        }
+      />
+    );
+  }
+  // Show the component only when the user is logged in
+  // Otherwise, redirect the user to /signin page
+  // <Route
+  //   {...rest}
+  //   render={
+  //     (props) => {
+  //       if (Component) {
+  //         return <Component {...props} />;
+  //       }
+  //       if (!isLogin) {
+  //         return <Redirect to="/login" />;
+  //       }
+  //       return null;
+  //     }
+  //     // isLogin() ? <Component {...props} /> : <Redirect to="/login" />
+  //   }
+  // />
+}

--- a/frontend/src/components/common/MenuList.js
+++ b/frontend/src/components/common/MenuList.js
@@ -22,7 +22,6 @@ export default function MenuList() {
         setClassification(res.data.classification);
         console.log("불러오기 성공");
         console.log(res.data);
-        console.log(APImenu);
       })
       .catch((err) => console.error(err))
       .finally(console.log(APImenu));
@@ -78,8 +77,14 @@ export default function MenuList() {
     return data.itemClass === "음료";
   });
 
-  let [targetArray, setTargetArray] = useState(BrunchList);
+  let [targetArray, setTargetArray] = useState([]);
+  console.log(targetArray);
+  useEffect(() => {
+    setTargetArray(CoffeeList);
+  }, []);
 
+  console.log("CoffeeList", CoffeeList);
+  console.log("targetArray", targetArray);
   const handleButtonClick = (e) => {
     console.log(e.target.value);
     if (e.target.value === "브런치") {
@@ -104,6 +109,7 @@ export default function MenuList() {
                 name="menu"
                 value={menu}
                 id="menu"
+                defaultChecked={menu === "커피"}
                 onChange={handleButtonClick}
               ></InputWrap>
               <ButtonWrap>{menu}</ButtonWrap>

--- a/frontend/src/components/utils/isLogin1.js
+++ b/frontend/src/components/utils/isLogin1.js
@@ -1,0 +1,2 @@
+const isLogin1 = () => !!localStorage.getItem("token1");
+export default isLogin1;

--- a/frontend/src/components/utils/isLogin2.js
+++ b/frontend/src/components/utils/isLogin2.js
@@ -1,0 +1,2 @@
+const isLogin2 = () => !!localStorage.getItem("token2");
+export default isLogin2;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -6,7 +6,7 @@ import axios from "axios";
 
 axios.defaults.withCredentials = true;
 axios.defaults.baseURL = "http://127.0.0.1:5000";
-export default function Login({ props, name }) {
+export default function Login() {
   const history = useHistory();
   const [Id, setId] = useState("");
   const [Password, setPassword] = useState("");
@@ -22,10 +22,11 @@ export default function Login({ props, name }) {
           },
         })
         .then((res) => {
-          console.log(JSON.stringify(res));
-          console.log("res.data.accessToken : " + res.data);
-          console.log(res.data);
-          axios.defaults.headers.common["Authorization"] = "Bearer " + res.data;
+          console.log(res);
+          console.log("res.data.accessToken : " + res.data.jwt_token);
+          localStorage.setItem("token1", res.data.jwt_token);
+          axios.defaults.headers.common["Authorization"] =
+            "Bearer " + res.data.jwt_token;
           history.push("/manager");
         })
         .catch((ex) => {
@@ -39,6 +40,8 @@ export default function Login({ props, name }) {
 
   useEffect(() => {
     console.log("LoginPage render ...");
+    localStorage.setItem("token1", "");
+    localStorage.setItem("token2", "");
   }, []);
 
   const onIdHandler = (event) => {

--- a/frontend/src/pages/StaffLogin.js
+++ b/frontend/src/pages/StaffLogin.js
@@ -22,10 +22,11 @@ export default function Login({ props, name }) {
           },
         })
         .then((res) => {
-          console.log(JSON.stringify(res));
-          console.log("res.data.accessToken : " + res.data);
-          console.log(res.data);
-          axios.defaults.headers.common["Authorization"] = "Bearer " + res.data;
+          console.log(res);
+          console.log("res.data.accessToken : " + res.data.jwt_token);
+          localStorage.setItem("token2", res.data.jwt_token);
+          axios.defaults.headers.common["Authorization"] =
+            "Bearer " + res.data.jwt_token;
           history.push("/staff");
         })
         .catch((ex) => {
@@ -38,7 +39,9 @@ export default function Login({ props, name }) {
   };
 
   useEffect(() => {
-    console.log("LoginPage render ...");
+    console.log("StaffLogin Page render ...");
+    localStorage.setItem("token1", "");
+    localStorage.setItem("token2", "");
   }, []);
 
   const onIdHandler = (event) => {
@@ -61,7 +64,7 @@ export default function Login({ props, name }) {
         <NameWrap>
           ABC COFFEE-
           <br />
-          &nbsp;&nbsp;&nbsp;&nbsp;manager
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Staff
         </NameWrap>
       </TitleWrap>
       <LoginWrap>


### PR DESCRIPTION
- [x] localStorage에서 token1(관리자), token2(직원)을 로그인 시 저장
- [x] /manager(관리자 페이지), /staff(직원 페이지) 로그인 시 token1, token2의 getItem 여부에 따라 라우팅 여부 결정
  - token1 보유시 /manager(관리자 페이지) 접근 가능, /staff(직원 페이지) 접근 불가
  - token2 보유시 /staff(직원 페이지) 접근 가능, /manager(관리자 페이지) 접근 불가
- [x] 불필요한 props.loginCallBack 함수 삭제