### PR TITLE
Hotfix/order cancel logic

### DIFF
--- a/backend/api/order.py
+++ b/backend/api/order.py
@@ -76,7 +76,7 @@ class COrderCode(Resource):
         b_CnlRequest = dct_Input['isCancel']
 
         #주문서에 주문 번호가 없음
-        if not utils.to_int(orderCode):
+        if not cls_Q.check_order(int(orderCode)):
             return jsonify(const.SUCCESS_FALSE_RESPONSE)
         
         if b_CnlRequest:

--- a/backend/lib/UtilsSE2.py
+++ b/backend/lib/UtilsSE2.py
@@ -170,12 +170,12 @@ class LinkedQueue(object):
     # 즉 앞부터 확인하여 4개째 찾는 주문번호가 나오지 않는다면 true를 리턴하고 그게 아니면 false를 리턴한다.
     # 주문번호는 node.data(dict형 자료)의 key값이다.
     def check_cancellable(self, nOrderNo: int) -> bool:
-        b_Available: bool = False
+        b_Available: bool = True
         p_Curs: Node = self._headPoint
         n_Count: int = 0
         while p_Curs:
             if nOrderNo in p_Curs.data.keys() or n_Count == 5:
-                b_Available = True
+                b_Available = False
                 break
 
             p_Curs = p_Curs.nextLink


### PR DESCRIPTION
[Fix] 주문 취소 로직

의미 없는 조건문을 업데이트하고 다음과 같이 의도한 바대로 필터링할 수 있도록 수정
1. 주문서에 주문이 없는 경우
2. 주문서에 주문이 있는데 취소가 불가능한 경우(주문 완료 임박)
3. 주문서에 주문이 있고 취소 완료한 경우
4. 주문서에 주문이 있지만 서버 에러로 취소하지 못한 경우